### PR TITLE
Add encryption/decryption of BSNs

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,14 @@ In case more permisions are missing from the expected response, or a BSN search 
 most likely the scope *benk-brp-landelijk* or *benk-brp-zoekvraag-postcode-huisnummer-landelijk* is missing.
 This will limit the search to persons within Amsterdam only.
 
+## Encryption/decryption of burgerservicenummers
+
+For users with the scope *benk-brp-encrypt-bsn* all burgerservicenummers in the response will be
+encrypted. Subsequent calls to the API can be made with the encrypted burgerservicenummers and will
+be decrypted when the scope is present. The audit logs will still contain the original value.
+
+When unecrypted burgerservicenummers are in requests with the scope present, a permission denied
+response will be returned.
 
 ## Available Endpoints
 
@@ -155,6 +163,8 @@ Hardening deployment:
 * `CORS_ALLOW_ALL_ORIGINS` can be true/false to allow all websites to connect.
 * `CORS_ALLOWED_ORIGINS` allows a list of origin URLs to use.
 * `CORS_ALLOWED_ORIGIN_REGEXES` supports a list of regex patterns fow allowed origins.
+* `HAAL_CENTRAAL_BRP_ENCRYPTION_SALTS` a list of salts used to encrypt data. The first item will be used to encrypt
+   new values, the other values can be used for rotation.
 
 # Developer Notes
 

--- a/src/haal_centraal_proxy/bevragingen/encryption.py
+++ b/src/haal_centraal_proxy/bevragingen/encryption.py
@@ -14,7 +14,7 @@ class DecryptionFailed(Exception):
 def decrypt(value: Any) -> str:
     fernet = _get_fernet()
     try:
-        decrypted_value = fernet.decrypt(bytes(value, "utf-8")).decode("utf-8")
+        decrypted_value = fernet.decrypt(value.encode("utf-8")).decode("utf-8")
     except InvalidToken as err:
         raise DecryptionFailed("Value failed to decrypt") from err
     return decrypted_value
@@ -24,7 +24,7 @@ def encrypt(value: Any) -> str:
     fernet = _get_fernet()
     if not isinstance(value, str):
         value = str(value)
-    return fernet.encrypt(bytes(value, "utf-8")).decode("utf-8")
+    return fernet.encrypt(value.encode("utf-8")).decode("utf-8")
 
 
 def _get_keys() -> list[bytes]:

--- a/src/haal_centraal_proxy/bevragingen/encryption.py
+++ b/src/haal_centraal_proxy/bevragingen/encryption.py
@@ -1,0 +1,47 @@
+import base64
+from typing import Any
+
+from cryptography.fernet import Fernet, InvalidToken, MultiFernet
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.kdf.pbkdf2 import PBKDF2HMAC
+from django.conf import settings
+
+
+class DecryptionFailed(Exception):
+    pass
+
+
+def decrypt(value: Any) -> str:
+    fernet = _get_fernet()
+    try:
+        decrypted_value = fernet.decrypt(bytes(value, "utf-8")).decode("utf-8")
+    except InvalidToken as err:
+        raise DecryptionFailed("Value failed to decrypt") from err
+    return decrypted_value
+
+
+def encrypt(value: Any) -> str:
+    fernet = _get_fernet()
+    if not isinstance(value, str):
+        value = str(value)
+    return fernet.encrypt(bytes(value, "utf-8")).decode("utf-8")
+
+
+def _get_keys() -> list[bytes]:
+    keys = []
+    secret_key = settings.SECRET_KEY
+    salt_keys = settings.HAAL_CENTRAAL_BRP_ENCRYPTION_SALTS
+    for salt_key in salt_keys:
+        salt = bytes(salt_key, "utf-8")
+        kdf = PBKDF2HMAC(
+            algorithm=hashes.SHA256(),
+            length=32,
+            salt=salt,
+            iterations=1_200_000,
+        )
+        keys.append(base64.urlsafe_b64encode(kdf.derive(secret_key.encode("utf-8"))))
+    return keys
+
+
+def _get_fernet() -> MultiFernet:
+    return MultiFernet([Fernet(k) for k in _get_keys()])

--- a/src/haal_centraal_proxy/settings.py
+++ b/src/haal_centraal_proxy/settings.py
@@ -346,3 +346,7 @@ HAAL_CENTRAAL_BRP_VERBLIJFPLAATS_HISTORIE_URL = env.str(
     "HAAL_CENTRAAL_BRP_VERBLIJFPLAATS_HISTORIE_URL",
     "https://demo-omgeving.haalcentraal.nl/haalcentraal/api/brphistorie/verblijfplaatshistorie",
 )
+
+HAAL_CENTRAAL_BRP_ENCRYPTION_SALTS = env.list(
+    "HAAL_CENTRAAL_BRP_ENCRYPTION_SALTS", default=["insecure"]
+)

--- a/src/requirements.in
+++ b/src/requirements.in
@@ -3,7 +3,7 @@ django-environ == 0.12.0
 django-cors-headers == 4.7.0
 django-healthchecks == 1.5.0
 #amsterdam-schema-tools[django] == 6.0.1
-datapunt-authorization-django == 1.6.0
+datapunt-authorization-django == 1.6.1
 djangorestframework == 3.16.0
 python-json-logger==3.3.0
 requests == 2.32.3

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -318,9 +318,9 @@ cryptography==44.0.2 \
     #   jwcrypto
     #   msal
     #   pyjwt
-datapunt-authorization-django==1.6.0 \
-    --hash=sha256:6b7640b81bb8bf5cee3276e7a55f5a2174f6e26cacb9b66e88acf957548254e2 \
-    --hash=sha256:a9cf03e8222bb4ad824d6ca03874799a62f65422e8ab79319cc615b1a57245ea
+datapunt-authorization-django==1.6.1 \
+    --hash=sha256:27565d59ed6ff3e3c83b6c04a09fcf76abff7a49b9b7ff5ad2319a9b580d4e7c \
+    --hash=sha256:c2ba6de31da21dd4e07419659a61bbaaa16588f403065174a42db71700882601
     # via -r requirements.in
 deprecated==1.2.18 \
     --hash=sha256:422b6f6d859da6f2ef57857761bfb392480502a64c3028ca9bbe86085d72115d \

--- a/src/requirements_dev.txt
+++ b/src/requirements_dev.txt
@@ -357,9 +357,9 @@ cryptography==44.0.2 \
     #   jwcrypto
     #   msal
     #   pyjwt
-datapunt-authorization-django==1.6.0 \
-    --hash=sha256:6b7640b81bb8bf5cee3276e7a55f5a2174f6e26cacb9b66e88acf957548254e2 \
-    --hash=sha256:a9cf03e8222bb4ad824d6ca03874799a62f65422e8ab79319cc615b1a57245ea
+datapunt-authorization-django==1.6.1 \
+    --hash=sha256:27565d59ed6ff3e3c83b6c04a09fcf76abff7a49b9b7ff5ad2319a9b580d4e7c \
+    --hash=sha256:c2ba6de31da21dd4e07419659a61bbaaa16588f403065174a42db71700882601
     # via -r ./requirements.in
 deprecated==1.2.18 \
     --hash=sha256:422b6f6d859da6f2ef57857761bfb392480502a64c3028ca9bbe86085d72115d \

--- a/src/tests/test_api/test_views_verblijfplaatshistorie.py
+++ b/src/tests/test_api/test_views_verblijfplaatshistorie.py
@@ -103,6 +103,7 @@ class TestBrpVerblijfplaatshistorieView:
 
         # Create an encrypted BSN to use in the request
         encrypted_bsn = encryption.encrypt("999993240")
+        assert encrypted_bsn.startswith("gAAAAABoJc")
 
         response = api_client.post(
             url,


### PR DESCRIPTION
BSNs will be encrypted in each response when the user has a specified scope. In the logs the unencrypted bsn will still be visible. In the post requests BSNs will be decrypted