### PR TITLE
Handle errors as expected

### DIFF
--- a/src/haal_centraal_proxy/bevragingen/client.py
+++ b/src/haal_centraal_proxy/bevragingen/client.py
@@ -210,7 +210,7 @@ class BrpClient:
         content_type = response.headers.get("content-type", "")
         remote_json = (
             orjson.loads(response.content)
-            if content_type in ("application/json", "application/problem+json")
+            if any(ct in content_type for ct in ["application/json", "application/problem+json"])
             else None
         )
         detail_message = response.text if not content_type.startswith("text/html") else None

--- a/src/haal_centraal_proxy/bevragingen/exceptions.py
+++ b/src/haal_centraal_proxy/bevragingen/exceptions.py
@@ -2,7 +2,10 @@
 
 from rest_framework import exceptions, status
 
-CLASS_BY_CODE = {e.status_code: e for e in (exceptions.ParseError, exceptions.NotFound)}
+CLASS_BY_CODE = {
+    e.status_code: e
+    for e in (exceptions.ParseError, exceptions.PermissionDenied, exceptions.NotFound)
+}
 
 
 class BadGateway(exceptions.APIException):

--- a/src/tests/test_api/test_views_base.py
+++ b/src/tests/test_api/test_views_base.py
@@ -109,8 +109,12 @@ class TestBaseProxyView:
             "type": "https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.3",
         }
 
-    def test_error_response(self, api_client, requests_mock, caplog, common_headers):
-        """Prove that Haal Centraal errors are handled gracefully."""
+    @pytest.mark.parametrize(
+        "content_type",
+        ["application/json", "application/problem+json", "application/json;charset=utf-8"],
+    )
+    def test_error_response(self, api_client, requests_mock, caplog, common_headers, content_type):
+        """Prove that Haal Centraal errors are handled gracefully for all known content-types"""
         requests_mock.post(
             "/lap/api/brp/personen",
             json={
@@ -129,7 +133,7 @@ class TestBaseProxyView:
                 "code": "paramsValidation",
             },
             status_code=400,
-            headers={"content-type": "application/json"},
+            headers={"content-type": content_type},
         )
 
         url = reverse("brp-personen")


### PR DESCRIPTION
Some errors were not handled properly, resulting in a 5xx error, due to a mismatch on content-type in our error handling. We were also missing the 403 error in a mapping dictionary which raised a KeyError.