### PR TITLE
Remove soortVerbintenis from requests

### DIFF
--- a/src/brp_amsterdam_api/bevragingen/clients/brp_v.py
+++ b/src/brp_amsterdam_api/bevragingen/clients/brp_v.py
@@ -24,12 +24,6 @@ BRP_CATEGORY_MAPPING = {
         "function": derive_description,
         "args": "GENDER_CODE_TABLE",
     },
-    "soortVerbintenis.code": "05.15.10",
-    "soortVerbintenis.omschrijving": {
-        "source": "soortVerbintenis.code",
-        "function": derive_description,
-        "args": "ENGAGEMENT_TYPE_TABLE",
-    },
     "naam.voornamen": "05.02.10",
     "naam.adellijkeTitelPredicaat": "05.02.20",
     "naam.voorvoegsel": "05.02.30",

--- a/src/tests/test_api/test_clients.py
+++ b/src/tests/test_api/test_clients.py
@@ -26,11 +26,6 @@ class TestBrpVAdhocServiceClient:
         _derive_values(data)
         assert data["geboorte"]["land"]["omschrijving"] == "Nederland"
 
-    def test_derive_engagement_type(self):
-        data = {"soortVerbintenis": {"code": "P"}}
-        _derive_values(data)
-        assert data["soortVerbintenis"]["omschrijving"] == "geregistreerd partnerschap"
-
     def test_derive_reason_dissolution(self):
         data = {"ontbindingHuwelijkPartnerschap": {"reden": {"code": "S"}}}
         _derive_values(data)

--- a/src/tests/test_api/test_views_partnerhistorie.py
+++ b/src/tests/test_api/test_views_partnerhistorie.py
@@ -48,7 +48,6 @@ class TestBrpPartnerhistorieView:
                             "geslachtsnaam": "Arendsen",
                             "voorletters": "A.",
                         },
-                        "soortVerbintenis": {"code": "H", "omschrijving": "huwelijk"},
                     }
                 ]
             }
@@ -166,10 +165,10 @@ class TestBrpPartnerhistorieView:
                             "voornamen": "Adam",
                             "voorvoegsel": None,
                         },
-                        "soortVerbintenis": {"code": "H", "omschrijving": "huwelijk"},
                         "ontbindingHuwelijkPartnerschap": {
                             "datum": None,
                         },
+                        "soortVerbintenis": None,
                     }
                 ]
             }
@@ -221,10 +220,6 @@ class TestBrpPartnerhistorieView:
                             "voorletters": "A.",
                             "voornamen": "Ayse",
                         },
-                        "soortVerbintenis": {
-                            "code": "H",
-                            "omschrijving": "huwelijk",
-                        },
                     },
                     {
                         "aangaanHuwelijkPartnerschap": {
@@ -254,10 +249,6 @@ class TestBrpPartnerhistorieView:
                                 "langFormaat": "21 september 2003",
                                 "type": "Datum",
                             },
-                        },
-                        "soortVerbintenis": {
-                            "code": "H",
-                            "omschrijving": "huwelijk",
                         },
                     },
                 ],
@@ -303,10 +294,6 @@ class TestBrpPartnerhistorieView:
                             "voorletters": "K.",
                             "voornamen": "Koosje",
                             "voorvoegsel": "van",
-                        },
-                        "soortVerbintenis": {
-                            "code": "P",
-                            "omschrijving": "geregistreerd partnerschap",
                         },
                         "aangaanHuwelijkPartnerschap": {
                             "datum": {


### PR DESCRIPTION
We don't have the correct authorization for this field, so we remove it from out requests