### PR TITLE
Change BRP logging to an array of BSN's instead of separate rows and add logsize

### DIFF
--- a/src/brp_amsterdam_api/bevragingen/loghandler.py
+++ b/src/brp_amsterdam_api/bevragingen/loghandler.py
@@ -36,6 +36,8 @@ class BRPAuditLogHandler(logging.Handler):
         # The custom jsonformatter returns a json string, so we'll convert it to python
         logs = [json.loads(self.format(r)) for r in record]
 
+        # Add logSize to each log, so BenK can use the gzippedResponse for large logs
+        logs = [{**log, "logSize": len(json.dumps(log).encode("utf-8"))} for log in logs]
         try:
             self._client.upload(
                 rule_id=self.rule_id,

--- a/src/brp_amsterdam_api/bevragingen/views/base.py
+++ b/src/brp_amsterdam_api/bevragingen/views/base.py
@@ -317,6 +317,7 @@ class BaseProxyView(ClientMixin, APIView):
         Per service type, it may need more refinement.
         """
         extra = extra or {}
+
         extra.update(
             {
                 **self.default_log_fields,

--- a/src/brp_amsterdam_api/bevragingen/views/base.py
+++ b/src/brp_amsterdam_api/bevragingen/views/base.py
@@ -340,7 +340,10 @@ class BaseProxyView(ClientMixin, APIView):
             if isinstance(hc_request["burgerservicenummer"], str):
                 request_burgerservicenummers = [hc_request["burgerservicenummer"]]
             elif isinstance(hc_request["burgerservicenummer"], list):
-                request_burgerservicenummers = hc_request["burgerservicenummer"]
+                # Make sure all logged BSN's are a string
+                request_burgerservicenummers = [
+                    str(bsn) for bsn in hc_request["burgerservicenummer"]
+                ]
 
             # Join the two possible lists and remove duplicates
             extra["burgerservicenummers"] = list(

--- a/src/brp_amsterdam_api/bevragingen/views/base.py
+++ b/src/brp_amsterdam_api/bevragingen/views/base.py
@@ -331,6 +331,22 @@ class BaseProxyView(ClientMixin, APIView):
             }
         )
 
+        # Make sure burgerservicenummers and aNummers are always a (empty) list
+        extra["aNummers"] = extra.get("aNummers", [])
+        extra["burgerservicenummers"] = extra.get("burgerservicenummers", [])
+
+        # Always add BSN to the list of BSN's if it's submitted in the request
+        if "burgerservicenummer" in hc_request and hc_request["burgerservicenummer"] is not None:
+            if isinstance(hc_request["burgerservicenummer"], str):
+                request_burgerservicenummers = [hc_request["burgerservicenummer"]]
+            elif isinstance(hc_request["burgerservicenummer"], list):
+                request_burgerservicenummers = hc_request["burgerservicenummer"]
+
+            # Join the two possible lists and remove duplicates
+            extra["burgerservicenummers"] = list(
+                set(extra["burgerservicenummers"]) | set(request_burgerservicenummers)
+            )
+
         if exception is None:
             msg = (
                 "Access granted for '%(service)s.%(queryType)s' to '%(upn)s'"

--- a/src/brp_amsterdam_api/bevragingen/views/base.py
+++ b/src/brp_amsterdam_api/bevragingen/views/base.py
@@ -309,7 +309,7 @@ class BaseProxyView(ClientMixin, APIView):
         final_response: types.BaseResponse | None,
         needed_scopes: set[str],
         exception: OSError | APIException | None = None,
-        **kwargs,
+        extra_params: dict | None = None,
     ) -> None:
         """Perform the audit logging for the request/response.
 
@@ -325,8 +325,10 @@ class BaseProxyView(ClientMixin, APIView):
             "requestStarted": self.start_date,
             "requestProcessed": now(),
             "processingTime": (time.perf_counter_ns() - self.start_time) * 1e-9,
-            **kwargs,
         }
+
+        if extra_params:
+            extra.update(extra_params)
 
         if exception is None:
             msg = (
@@ -346,7 +348,6 @@ class BaseProxyView(ClientMixin, APIView):
                 "service": self.service_log_id,
                 "queryType": hc_request["type"],
                 "upn": self.upn,
-                **kwargs,
             },
             extra=extra,
         )

--- a/src/brp_amsterdam_api/bevragingen/views/base.py
+++ b/src/brp_amsterdam_api/bevragingen/views/base.py
@@ -309,6 +309,7 @@ class BaseProxyView(ClientMixin, APIView):
         final_response: types.BaseResponse | None,
         needed_scopes: set[str],
         exception: OSError | APIException | None = None,
+        **kwargs,
     ) -> None:
         """Perform the audit logging for the request/response.
 
@@ -324,6 +325,7 @@ class BaseProxyView(ClientMixin, APIView):
             "requestStarted": self.start_date,
             "requestProcessed": now(),
             "processingTime": (time.perf_counter_ns() - self.start_time) * 1e-9,
+            **kwargs,
         }
 
         if exception is None:
@@ -344,6 +346,7 @@ class BaseProxyView(ClientMixin, APIView):
                 "service": self.service_log_id,
                 "queryType": hc_request["type"],
                 "upn": self.upn,
+                **kwargs,
             },
             extra=extra,
         )

--- a/src/brp_amsterdam_api/bevragingen/views/base.py
+++ b/src/brp_amsterdam_api/bevragingen/views/base.py
@@ -309,26 +309,26 @@ class BaseProxyView(ClientMixin, APIView):
         final_response: types.BaseResponse | None,
         needed_scopes: set[str],
         exception: OSError | APIException | None = None,
-        extra_params: dict | None = None,
+        extra: dict | None = None,
     ) -> None:
         """Perform the audit logging for the request/response.
 
         This is a very basic global logging.
         Per service type, it may need more refinement.
         """
-        extra = {
-            **self.default_log_fields,
-            "needed": sorted(needed_scopes),
-            "request": request.data,
-            "hcRequest": hc_request,
-            "hcResponse": final_response or hc_response,
-            "requestStarted": self.start_date,
-            "requestProcessed": now(),
-            "processingTime": (time.perf_counter_ns() - self.start_time) * 1e-9,
-        }
-
-        if extra_params:
-            extra.update(extra_params)
+        extra = extra or {}
+        extra.update(
+            {
+                **self.default_log_fields,
+                "needed": sorted(needed_scopes),
+                "request": request.data,
+                "hcRequest": hc_request,
+                "hcResponse": final_response or hc_response,
+                "requestStarted": self.start_date,
+                "requestProcessed": now(),
+                "processingTime": (time.perf_counter_ns() - self.start_time) * 1e-9,
+            }
+        )
 
         if exception is None:
             msg = (

--- a/src/brp_amsterdam_api/bevragingen/views/bewoningen.py
+++ b/src/brp_amsterdam_api/bevragingen/views/bewoningen.py
@@ -65,11 +65,11 @@ class BrpBewoningenView(BaseProxyView):
             personen = []
             for bewoning in hc_response["bewoningen"]:
                 personen += bewoning.get("bewoners", []) + bewoning.get("mogelijkeBewoners", [])
-            bsns = []
+            burgerservicenummers = []
             for persoon in personen:
-                bsn = persoon.get("burgerservicenummer", None)
-                if bsn and bsn not in bsns:
-                    bsns.append(bsn)
+                burgerservicenummer = persoon.get("burgerservicenummer", None)
+                if burgerservicenummer and burgerservicenummer not in burgerservicenummers:
+                    burgerservicenummers.append(burgerservicenummer)
 
             super().log_access_granted(
                 request,
@@ -78,7 +78,7 @@ class BrpBewoningenView(BaseProxyView):
                 final_response,
                 needed_scopes,
                 exception,
-                extra_params={"burgerservicenummers": bsns},
+                extra={"burgerservicenummers": burgerservicenummers},
             )
             return
 

--- a/src/brp_amsterdam_api/bevragingen/views/bewoningen.py
+++ b/src/brp_amsterdam_api/bevragingen/views/bewoningen.py
@@ -78,7 +78,7 @@ class BrpBewoningenView(BaseProxyView):
                 final_response,
                 needed_scopes,
                 exception,
-                burgerservicenummers=bsns,
+                extra_params={"burgerservicenummers": bsns},
             )
             return
 

--- a/src/brp_amsterdam_api/bevragingen/views/bewoningen.py
+++ b/src/brp_amsterdam_api/bevragingen/views/bewoningen.py
@@ -80,46 +80,11 @@ class BrpBewoningenView(BaseProxyView):
                 exception,
                 burgerservicenummers=bsns,
             )
+            return
 
-            """
-            msg_params = {}
-            extra = {
-                "request": request.data,
-                "hcRequest": hc_request,
-                "hcResponse": final_response or hc_response,
-            }
-            msg = ["User %(upn)s retrieved using '%(service)s.%(queryType)s':"]
-            msg_params["burgerservicenummers"] = bsns
-            extra["burgerservicenummers"] = bsns.replace("?", None)
-            msg.append("burgerservicenummers=%(burgerservicenummers)s")
-                bsns.add(persoon.get("burgerservicenummer", None))
-            # bsns.discard(None) Is dit nodig? Voor als een persoon geen bsn heeft (???)
-            msg_params = {}
-            extra = {
-                "request": request.data,
-                "hcRequest": hc_request,
-                "hcResponse": final_response or hc_response,
-            }
-            msg = ["User %(upn)s retrieved using '%(service)s.%(queryType)s':"]
-            msg_params["burgerservicenummers"] = list(bsns)
-            extra["burgerservicenummers"] = list(bsns)
-            msg.append("burgerservicenummers=%(burgerservicenummers)s")
-
-            audit_log.info(
-                # Visible log message
-                " ".join(msg),
-                {
-                    "service": self.service_log_id,
-                    "queryType": hc_request["type"],
-                    "upn": self.upn,
-                    **msg_params,
-                },
-                # Extra JSON fields for log querying
-                extra={
-                    **self.default_log_fields,
-                    **extra,
-                },
-            )
+        super().log_access_granted(
+            request, hc_request, hc_response, final_response, needed_scopes, exception
+        )
 
     def _insert_null_values(
         self, hc_request: types.BaseQuery, hc_response: types.BaseResponse

--- a/src/brp_amsterdam_api/bevragingen/views/bewoningen.py
+++ b/src/brp_amsterdam_api/bevragingen/views/bewoningen.py
@@ -67,8 +67,8 @@ class BrpBewoningenView(BaseProxyView):
                 personen += bewoning.get("bewoners", []) + bewoning.get("mogelijkeBewoners", [])
             bsns = []
             for persoon in personen:
-                bsn = persoon.get("burgerservicenummer", "?")
-                if bsn not in bsns:
+                bsn = persoon.get("burgerservicenummer", None)
+                if bsn and bsn not in bsns:
                     bsns.append(bsn)
 
             super().log_access_granted(

--- a/src/brp_amsterdam_api/bevragingen/views/bewoningen.py
+++ b/src/brp_amsterdam_api/bevragingen/views/bewoningen.py
@@ -4,7 +4,7 @@ from rest_framework.exceptions import APIException
 from brp_amsterdam_api.bevragingen import fields, types
 from brp_amsterdam_api.bevragingen.permissions import ParameterPolicy
 
-from .base import BaseHealthCheckView, BaseProxyView, audit_log, group_dotted_names
+from .base import BaseHealthCheckView, BaseProxyView, group_dotted_names
 
 ALL_FIELD_NAMES = fields.read_config("rvig_brp_api/bewoningen/fields.csv")
 
@@ -59,17 +59,39 @@ class BrpBewoningenView(BaseProxyView):
         exception: OSError | APIException | None = None,
     ) -> None:
         """Extend logging to also include each BSN that was returned in the response"""
-        super().log_access_granted(
-            request, hc_request, hc_response, final_response, needed_scopes, exception
-        )
 
         if exception is None:
-            # Separate log message for every person that's being accessed.
+            # Create an array of BSNs for every person that's being accessed.
             personen = []
             for bewoning in hc_response["bewoningen"]:
                 personen += bewoning.get("bewoners", []) + bewoning.get("mogelijkeBewoners", [])
-            bsns = set()
+            bsns = []
             for persoon in personen:
+                bsn = persoon.get("burgerservicenummer", "?")
+                if bsn not in bsns:
+                    bsns.append(bsn)
+
+            super().log_access_granted(
+                request,
+                hc_request,
+                hc_response,
+                final_response,
+                needed_scopes,
+                exception,
+                burgerservicenummers=bsns,
+            )
+
+            """
+            msg_params = {}
+            extra = {
+                "request": request.data,
+                "hcRequest": hc_request,
+                "hcResponse": final_response or hc_response,
+            }
+            msg = ["User %(upn)s retrieved using '%(service)s.%(queryType)s':"]
+            msg_params["burgerservicenummers"] = bsns
+            extra["burgerservicenummers"] = bsns.replace("?", None)
+            msg.append("burgerservicenummers=%(burgerservicenummers)s")
                 bsns.add(persoon.get("burgerservicenummer", None))
             # bsns.discard(None) Is dit nodig? Voor als een persoon geen bsn heeft (???)
             msg_params = {}

--- a/src/brp_amsterdam_api/bevragingen/views/bewoningen.py
+++ b/src/brp_amsterdam_api/bevragingen/views/bewoningen.py
@@ -68,33 +68,36 @@ class BrpBewoningenView(BaseProxyView):
             personen = []
             for bewoning in hc_response["bewoningen"]:
                 personen += bewoning.get("bewoners", []) + bewoning.get("mogelijkeBewoners", [])
+            bsns = set()
             for persoon in personen:
-                msg_params = {}
-                extra = {
-                    "request": request.data,
-                    "hcRequest": hc_request,
-                    "hcResponse": final_response or hc_response,
-                }
-                msg = ["User %(upn)s retrieved using '%(service)s.%(queryType)s':"]
-                msg_params["burgerservicenummer"] = persoon.get("burgerservicenummer", "?")
-                extra["burgerservicenummer"] = persoon.get("burgerservicenummer", None)
-                msg.append("burgerservicenummer=%(burgerservicenummer)s")
+                bsns.add(persoon.get("burgerservicenummer", None))
+            # bsns.discard(None) Is dit nodig? Voor als een persoon geen bsn heeft (???)
+            msg_params = {}
+            extra = {
+                "request": request.data,
+                "hcRequest": hc_request,
+                "hcResponse": final_response or hc_response,
+            }
+            msg = ["User %(upn)s retrieved using '%(service)s.%(queryType)s':"]
+            msg_params["burgerservicenummers"] = list(bsns)
+            extra["burgerservicenummers"] = list(bsns)
+            msg.append("burgerservicenummers=%(burgerservicenummers)s")
 
-                audit_log.info(
-                    # Visible log message
-                    " ".join(msg),
-                    {
-                        "service": self.service_log_id,
-                        "queryType": hc_request["type"],
-                        "upn": self.upn,
-                        **msg_params,
-                    },
-                    # Extra JSON fields for log querying
-                    extra={
-                        **self.default_log_fields,
-                        **extra,
-                    },
-                )
+            audit_log.info(
+                # Visible log message
+                " ".join(msg),
+                {
+                    "service": self.service_log_id,
+                    "queryType": hc_request["type"],
+                    "upn": self.upn,
+                    **msg_params,
+                },
+                # Extra JSON fields for log querying
+                extra={
+                    **self.default_log_fields,
+                    **extra,
+                },
+            )
 
     def _insert_null_values(
         self, hc_request: types.BaseQuery, hc_response: types.BaseResponse

--- a/src/brp_amsterdam_api/bevragingen/views/bewoningen.py
+++ b/src/brp_amsterdam_api/bevragingen/views/bewoningen.py
@@ -1,3 +1,7 @@
+import base64
+import gzip
+import json
+
 from django.conf import settings
 from rest_framework.exceptions import APIException
 
@@ -57,9 +61,10 @@ class BrpBewoningenView(BaseProxyView):
         final_response: types.BewoningenResponse | None,
         needed_scopes: set[str],
         exception: OSError | APIException | None = None,
+        extra: dict | None = None,
     ) -> None:
-        """Extend logging to also include each BSN that was returned in the response"""
-
+        """Extend logging to also include each BSN that was returned in the response and
+        a gzippedResponse to get around azure limits on log size."""
         if exception is None:
             # Create an array of BSNs for every person that's being accessed.
             personen = []
@@ -71,6 +76,13 @@ class BrpBewoningenView(BaseProxyView):
                 if burgerservicenummer and burgerservicenummer not in burgerservicenummers:
                     burgerservicenummers.append(burgerservicenummer)
 
+            extra = {
+                "burgerservicenummers": burgerservicenummers,
+                "hcResponseGzip": base64.b64encode(
+                    gzip.compress(json.dumps(hc_response).encode("utf-8"))
+                ),
+            }
+
             super().log_access_granted(
                 request,
                 hc_request,
@@ -78,7 +90,7 @@ class BrpBewoningenView(BaseProxyView):
                 final_response,
                 needed_scopes,
                 exception,
-                extra={"burgerservicenummers": burgerservicenummers},
+                extra=extra,
             )
             return
 

--- a/src/brp_amsterdam_api/bevragingen/views/partnerhistorie.py
+++ b/src/brp_amsterdam_api/bevragingen/views/partnerhistorie.py
@@ -2,6 +2,7 @@ import logging
 
 from django.conf import settings
 from rest_framework import status
+from rest_framework.exceptions import APIException
 from rest_framework.request import Request
 
 from brp_amsterdam_api.bevragingen import fields, types
@@ -113,6 +114,43 @@ class BrpPartnerhistorieView(BaseProxyView):
         # even through the user has no access to these fields.
         if self.inserted_id_fields:
             self._hide_inserted_identifiers(hc_request, hc_response)
+
+    def log_access_granted(
+        self,
+        request,
+        hc_request: types.BaseQuery,
+        hc_response: types.BaseResponse | None,
+        final_response: types.BaseResponse | None,
+        needed_scopes: set[str],
+        exception: OSError | APIException | None = None,
+        extra: dict | None = None,
+    ) -> None:
+        """Extend logging to also include each BSN that was returned in the response"""
+
+        if exception is None:
+            # Create arrays of BSNs and aNummers for every person that's being accessed.
+            extra = {}
+            for id_field in self.always_insert_id_fields:
+                extra[f"{id_field}s"] = []
+                for partner in hc_response["partnerhistorie"]:
+                    value = partner.get(id_field, None)
+                    if value and value not in extra[f"{id_field}s"]:
+                        extra[f"{id_field}s"].append(value)
+
+            super().log_access_granted(
+                request,
+                hc_request,
+                hc_response,
+                final_response,
+                needed_scopes,
+                exception,
+                extra=extra,
+            )
+            return
+
+        super().log_access_granted(
+            request, hc_request, hc_response, final_response, needed_scopes, exception
+        )
 
     def _add_fields_filter(self, hc_request: types.PartnerhistorieQuery) -> None:
         """Determine all values for the "fields" parameter that the user has access to.

--- a/src/brp_amsterdam_api/bevragingen/views/personen.py
+++ b/src/brp_amsterdam_api/bevragingen/views/personen.py
@@ -215,7 +215,6 @@ class BrpPersonenView(BaseProxyView):
         """Extend logging to also include each BSN that was returned in the response"""
 
         if exception is None:
-
             # Create an arrays of BSNs and aNummers for every person that's being accessed.
             extra = {}
             for id_field in self.always_insert_id_fields:
@@ -234,6 +233,11 @@ class BrpPersonenView(BaseProxyView):
                 exception,
                 **extra,
             )
+            return
+
+        super().log_access_granted(
+            request, hc_request, hc_response, final_response, needed_scopes, exception
+        )
 
     def transform_request(self, hc_request: types.PersonenQuery) -> None:
         """Extra rules before passing the request to RvIG BRP API"""

--- a/src/brp_amsterdam_api/bevragingen/views/personen.py
+++ b/src/brp_amsterdam_api/bevragingen/views/personen.py
@@ -218,8 +218,8 @@ class BrpPersonenView(BaseProxyView):
             # Create arrays of BSNs and aNummers for every person that's being accessed.
             extra = {}
             for id_field in self.always_insert_id_fields:
+                extra[f"{id_field}s"] = []
                 for persoon in hc_response["personen"]:
-                    extra[f"{id_field}s"] = []
                     value = persoon.get(id_field, None)
                     if value and value not in extra[f"{id_field}s"]:
                         extra[f"{id_field}s"].append(value)

--- a/src/brp_amsterdam_api/bevragingen/views/personen.py
+++ b/src/brp_amsterdam_api/bevragingen/views/personen.py
@@ -213,40 +213,27 @@ class BrpPersonenView(BaseProxyView):
         exception: OSError | APIException | None = None,
     ) -> None:
         """Extend logging to also include each BSN that was returned in the response"""
-        super().log_access_granted(
-            request, hc_request, hc_response, final_response, needed_scopes, exception
-        )
 
         if exception is None:
-            # Separate log message for every person that's being accessed.
-            for persoon in hc_response["personen"]:
-                msg_params = {}
-                extra = {
-                    "request": request.data,
-                    "hcRequest": hc_request,
-                    "hcResponse": final_response or hc_response,
-                }
-                msg = ["User %(upn)s retrieved using '%(service)s.%(queryType)s':"]
-                for id_field in self.always_insert_id_fields:
-                    msg_params[id_field] = persoon.get(id_field, "?")
-                    extra[id_field] = persoon.get(id_field, None)
-                    msg.append(f"{id_field}=%({id_field})s")
 
-                audit_log.info(
-                    # Visible log message
-                    " ".join(msg),
-                    {
-                        "service": self.service_log_id,
-                        "queryType": hc_request["type"],
-                        "upn": self.upn,
-                        **msg_params,
-                    },
-                    # Extra JSON fields for log querying
-                    extra={
-                        **self.default_log_fields,
-                        **extra,
-                    },
-                )
+            # Create an arrays of BSNs and aNummers for every person that's being accessed.
+            extra = {}
+            for id_field in self.always_insert_id_fields:
+                for persoon in hc_response["personen"]:
+                    extra[f"{id_field}s"] = []
+                    value = persoon.get(id_field, "?")
+                    if value not in extra[f"{id_field}s"]:
+                        extra[f"{id_field}s"].append(value)
+
+            super().log_access_granted(
+                request,
+                hc_request,
+                hc_response,
+                final_response,
+                needed_scopes,
+                exception,
+                **extra,
+            )
 
     def transform_request(self, hc_request: types.PersonenQuery) -> None:
         """Extra rules before passing the request to RvIG BRP API"""

--- a/src/brp_amsterdam_api/bevragingen/views/personen.py
+++ b/src/brp_amsterdam_api/bevragingen/views/personen.py
@@ -231,7 +231,7 @@ class BrpPersonenView(BaseProxyView):
                 final_response,
                 needed_scopes,
                 exception,
-                **extra,
+                extra_params=extra,
             )
             return
 

--- a/src/brp_amsterdam_api/bevragingen/views/personen.py
+++ b/src/brp_amsterdam_api/bevragingen/views/personen.py
@@ -215,13 +215,13 @@ class BrpPersonenView(BaseProxyView):
         """Extend logging to also include each BSN that was returned in the response"""
 
         if exception is None:
-            # Create an arrays of BSNs and aNummers for every person that's being accessed.
+            # Create arrays of BSNs and aNummers for every person that's being accessed.
             extra = {}
             for id_field in self.always_insert_id_fields:
                 for persoon in hc_response["personen"]:
                     extra[f"{id_field}s"] = []
-                    value = persoon.get(id_field, "?")
-                    if value not in extra[f"{id_field}s"]:
+                    value = persoon.get(id_field, None)
+                    if value and value not in extra[f"{id_field}s"]:
                         extra[f"{id_field}s"].append(value)
 
             super().log_access_granted(

--- a/src/brp_amsterdam_api/bevragingen/views/personen.py
+++ b/src/brp_amsterdam_api/bevragingen/views/personen.py
@@ -231,7 +231,7 @@ class BrpPersonenView(BaseProxyView):
                 final_response,
                 needed_scopes,
                 exception,
-                extra_params=extra,
+                extra=extra,
             )
             return
 

--- a/src/tests/test_api/test_auditlog.py
+++ b/src/tests/test_api/test_auditlog.py
@@ -64,6 +64,8 @@ class TestAuditLogHandler:
         mock_log_upload.assert_called_with(
             rule_id="mock-rule-id", stream_name="mock-stream-name", logs=ANY
         )
+        # Assert logSize have been added to the logs
+        assert all("logSize" in log for log in mock_log_upload.call_args_list[0][1]["logs"])
 
         assert log_message in caplog.messages
 

--- a/src/tests/test_api/test_views_base.py
+++ b/src/tests/test_api/test_views_base.py
@@ -88,9 +88,8 @@ class TestBaseProxyView:
                 **common_headers,
             },
         )
-        print(caplog.messages)
+
         assert response.status_code == 502
-        print(response.json())
         assert any(
             m.startswith("Access granted for 'personen.ZoekMetPostcodeEnHuisnummer' to '")
             for m in caplog.messages

--- a/src/tests/test_api/test_views_base.py
+++ b/src/tests/test_api/test_views_base.py
@@ -88,7 +88,9 @@ class TestBaseProxyView:
                 **common_headers,
             },
         )
+        print(caplog.messages)
         assert response.status_code == 502
+        print(response.json())
         assert any(
             m.startswith("Access granted for 'personen.ZoekMetPostcodeEnHuisnummer' to '")
             for m in caplog.messages

--- a/src/tests/test_api/test_views_bewoningen.py
+++ b/src/tests/test_api/test_views_bewoningen.py
@@ -57,9 +57,6 @@ class TestBrpBewoningenView:
         assert log is not None
         assert log.burgerservicenummers == ["999993240", "999993241", "999991371"]
 
-        # Log message should contain the full request/response context
-        assert all(getattr(log, attr) for attr in ["request", "hcRequest", "hcResponse"])
-
     def test_address_id_search_deny(self, api_client, common_headers):
         """Prove that access is checked"""
         url = reverse("brp-bewoningen")

--- a/src/tests/test_api/test_views_bewoningen.py
+++ b/src/tests/test_api/test_views_bewoningen.py
@@ -51,19 +51,13 @@ class TestBrpBewoningenView:
 
         log_records = caplog.records
         log = next(
-            (
-                record
-                for record in log_records
-                if record.message.startswith("User text@example.com retrieved")
-            ),
+            (record for record in log_records if record.message.startswith("Access")),
             None,
         )
         assert log is not None
+        assert log.burgerservicenummers == ["999993240", "999993241", "999991371"]
 
-        bsns = log.burgerservicenummers
-        assert {"999993241", "999991371", "999993240"} == set(bsns)
-
-        # Log messages about retrieved BSN's should contain the full request/response context
+        # Log message should contain the full request/response context
         assert all(getattr(log, attr) for attr in ["request", "hcRequest", "hcResponse"])
 
     def test_address_id_search_deny(self, api_client, common_headers):

--- a/src/tests/test_api/test_views_bewoningen.py
+++ b/src/tests/test_api/test_views_bewoningen.py
@@ -167,3 +167,29 @@ class TestBrpBewoningenView:
                 },
             ],
         }
+
+    def test_gzipped_response_added_to_logs(
+        self, api_client, caplog, requests_mock, common_headers
+    ):
+        """Prove that the gzipped response is added to the logs"""
+        requests_mock.post(
+            "/lap/api/brp/bewoning/bewoningen",
+            json=self.RESPONSE_BEWONINGEN,
+            headers={"content-type": "application/json"},
+        )
+
+        url = reverse("brp-bewoningen")
+        token = build_jwt_token(["benk-brp-bewoning-api"])
+        api_client.post(
+            f"{url}?resultaat-formaat=volledig",
+            {
+                "type": "BewoningMetPeildatum",
+                "adresseerbaarObjectIdentificatie": "0518010000832200",
+                "peildatum": "2020-09-24",
+            },
+            headers={
+                "Authorization": f"Bearer {token}",
+                **common_headers,
+            },
+        )
+        assert any("hcResponseGzip" in r.__dict__ for r in caplog.records)

--- a/src/tests/test_api/test_views_bewoningen.py
+++ b/src/tests/test_api/test_views_bewoningen.py
@@ -49,30 +49,22 @@ class TestBrpBewoningenView:
         assert response.status_code == 200, response
         assert response.json() == self.RESPONSE_BEWONINGEN, response.data
 
-        log_messages = caplog.messages
-        for log_message in [
+        log_records = caplog.records
+        log = next(
             (
-                "User text@example.com retrieved using 'bewoningen.BewoningMetPeildatum':"
-                " burgerservicenummer=999993240"
+                record
+                for record in log_records
+                if record.message.startswith("User text@example.com retrieved")
             ),
-            (
-                "User text@example.com retrieved using 'bewoningen.BewoningMetPeildatum':"
-                " burgerservicenummer=999993241"
-            ),
-            (
-                "User text@example.com retrieved using 'bewoningen.BewoningMetPeildatum':"
-                " burgerservicenummer=999991371"
-            ),
-        ]:
-            assert log_message in log_messages
+            None,
+        )
+        assert log is not None
+
+        bsns = log.burgerservicenummers
+        assert {"999993241", "999991371", "999993240"} == set(bsns)
 
         # Log messages about retrieved BSN's should contain the full request/response context
-        assert any("retrieved using" in record.message for record in caplog.records)
-        for record in caplog.records:
-            if "retrieved using" in record.message:
-                assert all(
-                    getattr(record, attr) for attr in ["request", "hcRequest", "hcResponse"]
-                )
+        assert all(getattr(log, attr) for attr in ["request", "hcRequest", "hcResponse"])
 
     def test_address_id_search_deny(self, api_client, common_headers):
         """Prove that access is checked"""

--- a/src/tests/test_api/test_views_bewoningen.py
+++ b/src/tests/test_api/test_views_bewoningen.py
@@ -57,6 +57,9 @@ class TestBrpBewoningenView:
         assert log is not None
         assert log.burgerservicenummers == ["999993240", "999993241", "999991371"]
 
+        # Log message should contain the full request/response context
+        assert all(getattr(log, attr) for attr in ["request", "hcRequest", "hcResponse"])
+
     def test_address_id_search_deny(self, api_client, common_headers):
         """Prove that access is checked"""
         url = reverse("brp-bewoningen")

--- a/src/tests/test_api/test_views_partnerhistorie.py
+++ b/src/tests/test_api/test_views_partnerhistorie.py
@@ -306,6 +306,68 @@ class TestBrpPartnerhistorieView:
                 ],
             }
 
+    def test_partnerhistorie_bsns_logger(self, api_client, requests_mock, caplog, common_headers):
+        """Prove that bsns from both the request and response are logged."""
+        with open("tests/data/response-other-category.xml") as mock_response:
+            requests_mock.post("/gba-v/online/lo3services/adhoc", text=mock_response.read())
+
+            url = reverse("brp-partnerhistorie")
+            token = build_jwt_token(
+                [
+                    "benk-brp-personen-api",
+                    "benk-brp-partnerhistorie-api",
+                    "benk-brp-gegevensset-22",
+                ]
+            )
+            response = api_client.post(
+                f"{url}",
+                {"type": "RaadpleegMetBurgerservicenummer", "burgerservicenummer": "123456789"},
+                headers={
+                    "Authorization": f"Bearer {token}",
+                    **common_headers,
+                },
+            )
+            assert response.status_code == 200, response.data
+            assert response.json() == {
+                "partnerhistorie": [
+                    {
+                        "burgerservicenummer": "999998912",
+                        "geboorte": {
+                            "datum": {
+                                "datum": "1982-04-01",
+                                "langFormaat": "1 april 1982",
+                                "type": "Datum",
+                            },
+                        },
+                        "naam": {
+                            "geslachtsnaam": "Krabben",
+                            "voorletters": "K.",
+                            "voornamen": "Koosje",
+                            "voorvoegsel": "van",
+                        },
+                        "aangaanHuwelijkPartnerschap": {
+                            "datum": {
+                                "datum": "2019-04-01",
+                                "langFormaat": "1 april 2019",
+                                "type": "Datum",
+                            },
+                        },
+                    },
+                ],
+            }
+
+            log_records = caplog.records
+            log = next(
+                (record for record in log_records if record.message.startswith("Access")),
+                None,
+            )
+            assert log is not None
+            assert all(bsn in log.burgerservicenummers for bsn in ["123456789", "999998912"])
+            assert log.aNummers == []
+
+            # Log message should contain the full request/response context
+            assert all(getattr(log, attr) for attr in ["request", "hcRequest", "hcResponse"])
+
     def test_transform_includes_bsn(self):
         """Prove that BSN is added to the request for logging purposes even if the user has no
         permissions for this field.

--- a/src/tests/test_api/test_views_personen.py
+++ b/src/tests/test_api/test_views_personen.py
@@ -910,18 +910,34 @@ class TestBrpPersonenView:
         assert request_data["burgerservicenummer"][0] == "999993367"
 
         # Expect the unencrypted bsn to show up in the logs
-        log_messages = caplog.messages
-        for log_message in [
+        log_records = caplog.records
+        log_1 = next(
             (
-                "User text@example.com retrieved using 'personen.ZoekMetPostcodeEnHuisnummer':"
-                " aNummer=? burgerservicenummer=999993367"
+                record
+                for record in log_records
+                if record.message.startswith(
+                    "Access granted for 'personen.ZoekMetPostcodeEnHuisnummer"
+                )
             ),
+            None,
+        )
+        assert log_1 is not None
+        assert log_1.burgerservicenummers == ["999993367"]
+        assert log_1.aNummers == ["?"]
+
+        log_2 = next(
             (
-                "User text@example.com retrieved using 'personen.RaadpleegMetBurgerservicenummer':"
-                " aNummer=? burgerservicenummer=999993367"
+                record
+                for record in log_records
+                if record.message.startswith(
+                    "Access granted for 'personen.RaadpleegMetBurgerservicenummer"
+                )
             ),
-        ]:
-            assert log_message in log_messages
+            None,
+        )
+        assert log_2 is not None
+        assert log_2.burgerservicenummers == ["999993367"]
+        assert log_2.aNummers == ["?"]
 
     def test_encryption_salt_required(self, api_client, requests_mock, caplog, common_headers):
         """Prove that the correlation id is used as a salt to encrypt/decrypt"""

--- a/src/tests/test_api/test_views_personen.py
+++ b/src/tests/test_api/test_views_personen.py
@@ -831,28 +831,17 @@ class TestBrpPersonenView:
                 },
             ],
         }
-        log_messages = caplog.messages
-        for log_message in [
-            "User doesn't request ID field burgerservicenummer, only adding for internal logging",
-            "Removing additional identifier fields from response: burgerservicenummer",
-            (
-                "User text@example.com retrieved using 'personen.ZoekMetPostcodeEnHuisnummer':"
-                " aNummer=? burgerservicenummer=999993240"
-            ),
-            (
-                "User text@example.com retrieved using 'personen.ZoekMetPostcodeEnHuisnummer':"
-                " aNummer=? burgerservicenummer=999993252"
-            ),
-        ]:
-            assert log_message in log_messages
+        log_records = caplog.records
+        log = next(
+            (record for record in log_records if record.message.startswith("Access")),
+            None,
+        )
+        assert log is not None
+        assert log.burgerservicenummers == ["999993252"]
+        assert log.aNummers == ["?"]
 
-        # Log messages about retrieved BSN's should contain the full request/response context
-        assert any("retrieved using" in record.message for record in caplog.records)
-        for record in caplog.records:
-            if "retrieved using" in record.message:
-                assert all(
-                    getattr(record, attr) for attr in ["request", "hcRequest", "hcResponse"]
-                )
+        # Log message should contain the full request/response context
+        assert all(getattr(log, attr) for attr in ["request", "hcRequest", "hcResponse"])
 
     def test_encrypt_decrypt_bsn(self, api_client, requests_mock, caplog, common_headers):
         """Prove encryption/decryption of BSNs works."""

--- a/src/tests/test_api/test_views_personen.py
+++ b/src/tests/test_api/test_views_personen.py
@@ -837,7 +837,7 @@ class TestBrpPersonenView:
             None,
         )
         assert log is not None
-        assert log.burgerservicenummers == ["999993252"]
+        assert log.burgerservicenummers == ["999993240", "999993252"]
         assert log.aNummers == []
 
         # Log message should contain the full request/response context

--- a/src/tests/test_api/test_views_personen.py
+++ b/src/tests/test_api/test_views_personen.py
@@ -843,6 +843,80 @@ class TestBrpPersonenView:
         # Log message should contain the full request/response context
         assert all(getattr(log, attr) for attr in ["request", "hcRequest", "hcResponse"])
 
+    def test_log_requested_bsns(
+        self, api_client, requests_mock, caplog, monkeypatch, common_headers
+    ):
+        """
+        Prove that requested BSNs are always logged and not duplicated between request and response
+        """
+        requests_mock.post(
+            "/lap/api/brp/personen",
+            json={
+                "type": "RaadpleegMetBurgerservicenummer",
+                "personen": [
+                    {
+                        "burgerservicenummer": "999993240",
+                    },
+                    {
+                        "burgerservicenummer": "999993252",
+                    },
+                ],
+            },
+            headers={"content-type": "application/json"},
+        )
+
+        url = reverse("brp-personen")
+        scopes = [
+            "benk-brp-personen-api",
+            "benk-brp-zoekvraag-bsn",
+            "benk-brp-gegevensset-1",
+        ]
+        response = api_client.post(
+            url,
+            {
+                "type": "RaadpleegMetBurgerservicenummer",
+                "burgerservicenummer": ["999993367", "999993252"],
+                "fields": ["burgerservicenummer"],
+            },
+            headers={
+                "Authorization": f"Bearer {build_jwt_token(scopes)}",
+                **common_headers,
+            },
+        )
+        assert response.status_code == 200, response.data
+        response = response.json()
+
+        assert response == {
+            "type": "RaadpleegMetBurgerservicenummer",
+            "personen": [
+                # burgerservicenummer retrieved from endpoint, but stripped before sending response
+                {
+                    "burgerservicenummer": "999993240",
+                },
+                {
+                    "burgerservicenummer": "999993252",
+                },
+            ],
+        }
+        log_records = caplog.records
+        log = next(
+            (record for record in log_records if record.message.startswith("Access")),
+            None,
+        )
+        assert log is not None
+        assert all(
+            bsn in log.burgerservicenummers for bsn in ["999993240", "999993252", "999993367"]
+        )
+        # Make sure there are no duplicates in de bsn log
+        duplicates = [
+            i for i in set(log.burgerservicenummers) if log.burgerservicenummers.count(i) > 1
+        ]
+        assert duplicates == []
+        assert log.aNummers == []
+
+        # Log message should contain the full request/response context
+        assert all(getattr(log, attr) for attr in ["request", "hcRequest", "hcResponse"])
+
     def test_encrypt_decrypt_bsn(self, api_client, requests_mock, caplog, common_headers):
         """Prove encryption/decryption of BSNs works."""
         requests_mock.post(

--- a/src/tests/test_api/test_views_personen.py
+++ b/src/tests/test_api/test_views_personen.py
@@ -838,7 +838,7 @@ class TestBrpPersonenView:
         )
         assert log is not None
         assert log.burgerservicenummers == ["999993252"]
-        assert log.aNummers == ["?"]
+        assert log.aNummers == []
 
         # Log message should contain the full request/response context
         assert all(getattr(log, attr) for attr in ["request", "hcRequest", "hcResponse"])
@@ -923,7 +923,7 @@ class TestBrpPersonenView:
         )
         assert log_1 is not None
         assert log_1.burgerservicenummers == ["999993367"]
-        assert log_1.aNummers == ["?"]
+        assert log_1.aNummers == []
 
         log_2 = next(
             (
@@ -937,7 +937,7 @@ class TestBrpPersonenView:
         )
         assert log_2 is not None
         assert log_2.burgerservicenummers == ["999993367"]
-        assert log_2.aNummers == ["?"]
+        assert log_2.aNummers == []
 
     def test_encryption_salt_required(self, api_client, requests_mock, caplog, common_headers):
         """Prove that the correlation id is used as a salt to encrypt/decrypt"""


### PR DESCRIPTION
We loggen niet meer een aparte regel voor iedere bsn, maar dit wordt nu in een array opgevangen. Duplicaten worden verwijderd. Ook BSN's die in het request voorkomen worden nu gelogd.

Voor de te grote logs die uit de bewoningen API voortkomen is logsize toegevoegd en een gegzipte respons. Dit wordt door BenK gebruikt als de normale response te groot blijkt te zijn.